### PR TITLE
correct typo in SMPP documentation

### DIFF
--- a/check_smpp.pl
+++ b/check_smpp.pl
@@ -53,9 +53,9 @@
 #                              [--system-type] [--service-type] [--data-coding]
 # -h, --help
 #        print this help message
-# -v, --version
+# -V, --version
 #        print version
-# -V, --verbose
+# -v, --verbose
 #        print extra debugging information
 # -H, --host=HOST
 #        hostname or IP address of host to check


### PR DESCRIPTION
The casing for the verbose and version commands were the wrong
way around in the inital comments; this commit fixes that.
